### PR TITLE
Allow online and offline mode for public packages

### DIFF
--- a/src/OfflinePackageStorage.js
+++ b/src/OfflinePackageStorage.js
@@ -16,6 +16,10 @@ import LocalFS from '@verdaccio/local-storage/lib/local-fs';
  * @see https://github.com/verdaccio/monorepo/tree/master/plugins/local-storage
  */
 export default class OfflinePackageStorage extends LocalFS {
+  constructor(path, logger, offlineMode) {
+    super(path, logger);
+    this.offlineMode = offlineMode;
+  }
   /**
    * Computes a package's definition that only lists the locally available versions.
    *
@@ -43,7 +47,7 @@ export default class OfflinePackageStorage extends LocalFS {
               '[verdaccio-offline-storage/readPackage/readdir] error discovering package "@{packageName}" files: @{err}'
             );
             cb(err);
-          } else {
+          } else if (this.offlineMode) {
             const localVersions = items
               .filter(item => item.endsWith('.tgz'))
               .map(item => item.substring(basename(name).length + 1, item.length - 4));
@@ -52,7 +56,7 @@ export default class OfflinePackageStorage extends LocalFS {
                 packageName: name,
                 count: localVersions.length,
               },
-              '[verdaccio-offline-storage/readPackage/readdir] discovered @{count} items for package: @{packageName}'
+              '[verdaccio-offline-storage/readPackage/readdir] offline mode - discovered @{count} items for package: @{packageName}'
             );
             const allVersions = Object.keys(data.versions);
             const originalVersionCount = allVersions.length;
@@ -61,7 +65,7 @@ export default class OfflinePackageStorage extends LocalFS {
                 packageName: name,
                 count: originalVersionCount,
               },
-              '[verdaccio-offline-storage/readPackage/readdir] analyzing @{count} declared versions for package: @{packageName}'
+              '[verdaccio-offline-storage/readPackage/readdir] offline mode - analyzing @{count} declared versions for package: @{packageName}'
             );
             for (const version of allVersions) {
               if (!localVersions.includes(version)) {
@@ -71,7 +75,7 @@ export default class OfflinePackageStorage extends LocalFS {
                     packageName: name,
                     version,
                   },
-                  '[verdaccio-offline-storage/readPackage/readdir] removed @{packageName}@@{version}'
+                  '[verdaccio-offline-storage/readPackage/readdir] offline mode - removed @{packageName}@@{version}'
                 );
               }
             }
@@ -80,7 +84,7 @@ export default class OfflinePackageStorage extends LocalFS {
                 packageName: name,
                 count: originalVersionCount - Object.keys(data.versions).length,
               },
-              '[verdaccio-offline-storage/readPackage/readdir] removed @{count} versions for package: @{packageName}'
+              '[verdaccio-offline-storage/readPackage/readdir] offline mode - removed @{count} versions for package: @{packageName}'
             );
             data['dist-tags'].latest = Object.keys(data.versions).sort((a, b) => cmp(b, a))[0];
             this.logger.trace(
@@ -88,7 +92,15 @@ export default class OfflinePackageStorage extends LocalFS {
                 packageName: name,
                 latest: data['dist-tags'].latest,
               },
-              '[verdaccio-offline-storage/readPackage/readdir] set latest version to @{latest} for package: @{packageName}'
+              '[verdaccio-offline-storage/readPackage/readdir] offline mode - set latest version to @{latest} for package: @{packageName}'
+            );
+            cb(null, data);
+          } else {
+            this.logger.trace(
+              {
+                packageName: name,
+              },
+              '[verdaccio-offline-storage/readPackage/readdir] online mode - local package @{packageName} found'
             );
             cb(null, data);
           }

--- a/src/OfflineStoragePlugin.js
+++ b/src/OfflineStoragePlugin.js
@@ -16,7 +16,6 @@ import OfflinePackageStorage from './OfflinePackageStorage';
 export default class OfflineStoragePlugin extends LocalDatabase {
   constructor(config, options) {
     super(config, options.logger);
-    this.offlineMode = config.uplinks === undefined || Object.keys(config.uplinks).length === 0;
   }
 
   /**
@@ -89,6 +88,8 @@ export default class OfflineStoragePlugin extends LocalDatabase {
    * @see https://verdaccio.org/docs/en/plugin-storage#api
    */
   getPackageStorage(packageName) {
-    return new OfflinePackageStorage(join(this.config.storage, packageName), this.logger, this.offlineMode);
+    const offlineMode = this.config.uplinks === undefined || Object.keys(this.config.uplinks).length === 0;
+
+    return new OfflinePackageStorage(join(this.config.storage, packageName), this.logger, offlineMode);
   }
 }

--- a/src/OfflineStoragePlugin.js
+++ b/src/OfflineStoragePlugin.js
@@ -16,6 +16,7 @@ import OfflinePackageStorage from './OfflinePackageStorage';
 export default class OfflineStoragePlugin extends LocalDatabase {
   constructor(config, options) {
     super(config, options.logger);
+    this.offlineMode = config.uplinks === undefined || Object.keys(config.uplinks).length === 0;
   }
 
   /**
@@ -88,6 +89,6 @@ export default class OfflineStoragePlugin extends LocalDatabase {
    * @see https://verdaccio.org/docs/en/plugin-storage#api
    */
   getPackageStorage(packageName) {
-    return new OfflinePackageStorage(join(this.config.storage, packageName), this.logger);
+    return new OfflinePackageStorage(join(this.config.storage, packageName), this.logger, this.offlineMode);
   }
 }


### PR DESCRIPTION
allow online mode, that fetches missing versions from the uplink, 
and allow existing offline mode, that fails if version doesn't exist locally. 

all depends on whether uplinks are defined or not.

Fixes issue https://github.com/g3ngar/verdaccio-offline-storage/issues/2